### PR TITLE
Add forked repo context to top-level README

### DIFF
--- a/README-brim.md
+++ b/README-brim.md
@@ -1,7 +1,0 @@
-# Zeek for Brim
-
-This repository contains the [Zeek](https://github.com/zeek/zeek) code plus any
-changes needed to produce the Zeek build artifacts used by the
-[Brim](https://github.com/brimsec/brim) application and its embedded
-[zq](https://github.com/brimsec/zq) daemon.
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+About This Repository
+---------------------
+This fork of [Zeek](https://github.com/zeek/zeek) was created by the
+development team at [Brim Data](https://www.brimdata.io/) for inclusion with
+[Brimcap](https://github.com/brimdata/brimcap) and the [Brim desktop app](https://github.com/brimdata/brim).
+Most of the changes relative to mainline Zeek relate to support on Windows for
+generatiing Zeek logs from pcaps.
+
+Community contributions are welcomed to assist with upstreaming the changes to
+mainline Zeek. Issue [zeek/951](https://github.com/zeek/zeek/issues/951) tracks this effort. As mainlining efforts have seen minimal traction thus far, help
+would also be appreciated in getting the changes to to work with newer Zeek
+releases, as the Zeek version on which this fork was based is now quite old.
+
 <h1 align="center">
 
 [![Zeek Logo](https://zeek.org/wp-content/uploads/2020/04/zeek-logo-without-text.png)](https:://www.zeek.org)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This fork of [Zeek](https://github.com/zeek/zeek) was created by the
 development team at [Brim Data](https://www.brimdata.io/) for inclusion with
 [Brimcap](https://github.com/brimdata/brimcap) and the [Brim desktop app](https://github.com/brimdata/brim).
 Most of the changes relative to mainline Zeek relate to support on Windows for
-generatiing Zeek logs from pcaps.
+generating Zeek logs from pcaps.
 
 Community contributions are welcomed to assist with upstreaming the changes to
 mainline Zeek. Issue [zeek/951](https://github.com/zeek/zeek/issues/951) tracks this effort. As mainlining efforts have seen minimal traction thus far, help


### PR DESCRIPTION
As Windows Defender no longer seems to pop up panicky messages when Brim is installed, it seems like the [Microsoft Windows beta limitations](https://github.com/brimdata/brim/wiki/Microsoft-Windows-beta-limitations) disclaimers can be removed soon. As that doc had also been a place to disclose the details of Brim's port of Zeek, this PR proposes moving that info to the README in the Zeek fork itself. Since this repo is linked to from Brimcap materials, it all seems like a more appropriate place to cover this for interested parties.