### PR TITLE
Clone repo over https

### DIFF
--- a/.github/workflows/brim.yml
+++ b/.github/workflows/brim.yml
@@ -30,7 +30,7 @@ jobs:
         name: Windows alternative for actions/checkout@v2
         run: |
           set -x
-          git clone --depth=1 --no-checkout --single-branch git://github.com/$GITHUB_REPOSITORY .
+          git clone --depth=1 --no-checkout --single-branch https://github.com/$GITHUB_REPOSITORY .
           git fetch --depth=1 origin $GITHUB_REF
           git -c core.symlinks=true checkout FETCH_HEAD -- ':(exclude)**/*:*'
           git submodule update --depth=1 --init --jobs $NUMBER_OF_PROCESSORS --recursive --single-branch


### PR DESCRIPTION
When submitting PR #58, the CI failed for Windows with this complaint:

> ```
> $ git clone --depth=1 --no-checkout --single-branch git://github.com/brimdata/zeek
> Cloning into 'zeek'...
> fatal: remote error: 
>   The unauthenticated git protocol on port 9418 is no longer supported.
> Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
> ```

Just changing to https:// should make it work.